### PR TITLE
Fix some filepaths to work on Linux

### DIFF
--- a/OpenMud.Midpiler.Compiler.Core/MsbuildDmlCompiler.cs
+++ b/OpenMud.Midpiler.Compiler.Core/MsbuildDmlCompiler.cs
@@ -108,13 +108,13 @@ public class MsBuildDmlCompiler
 
     private static (string bin, string pdb) DoProjectBuild(string projectPath, string msbuildtools)
     {
-        var binFile = Path.Join(projectPath, ".\\dmlbins\\DmlProject.dll");
-        var pdbFile = Path.Join(projectPath, ".\\dmlbins\\DmlProject.pdb");
+        var binFile = Path.Join(projectPath, "./dmlbins/DmlProject.dll");
+        var pdbFile = Path.Join(projectPath, "./dmlbins/DmlProject.pdb");
 
         var startInfo = new ProcessStartInfo
         {
             FileName = "dotnet",
-            Arguments = $"\"{msbuildtools}\\msbuild.dll\" -t:build,FodyTarget -p:OutDir=dmlbins \"{projectPath}\"",
+            Arguments = $"\"{msbuildtools}/MSBuild.dll\" -t:build,FodyTarget -p:OutDir=dmlbins \"{projectPath}\"",
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true
@@ -143,7 +143,7 @@ public class MsBuildDmlCompiler
         var startInfo = new ProcessStartInfo
         {
             FileName = "dotnet",
-            Arguments = $"\"{msbuildtools}\\msbuild.dll\" -t:restore \"{projectPath}\"",
+            Arguments = $"\"{msbuildtools}/MSBuild.dll\" -t:restore \"{projectPath}\"",
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true


### PR DESCRIPTION
Fixes some issues I ran into when trying to run this on Linux. I'm struggling to get the server/client working, but this at least gets the compiler finishing.

* Change `msbuild.dll` -> `MSBuild.dll` so it works on case-insensitive filesystems
* Change some back slashes to forward slashes

While I'm confident the behavior is equivalent on Windows, I have not tested it.