### PR TITLE
Fix verb bug

### DIFF
--- a/OpenMud.Midpiler.Compiler.Core/MsbuildDmlCompiler.cs
+++ b/OpenMud.Midpiler.Compiler.Core/MsbuildDmlCompiler.cs
@@ -222,7 +222,7 @@ public class MsBuildDmlCompiler
             .FirstOrDefault();
 
         if (buildAssembly == null)
-            throw new Exception("Not able to locate a VS Build Instance for .Net 7.0");
+            throw new Exception("Not able to locate a VS Build Instance for .Net 7.x; Install the .NET 7.x SDK from microsoft's website.");
 
         if (!MSBuildLocator.IsRegistered)
             MSBuildLocator.RegisterDefaults();

--- a/OpenMud.Mudpiler.Core/OpenMud.Mudpiler.Core.csproj
+++ b/OpenMud.Mudpiler.Core/OpenMud.Mudpiler.Core.csproj
@@ -10,9 +10,13 @@
 
 	<ItemGroup>
 		<Antlr4 Remove="Contexts\**" />
+		<Antlr4 Remove="Environment\**" />
 		<Compile Remove="Contexts\**" />
+		<Compile Remove="Environment\**" />
 		<EmbeddedResource Remove="Contexts\**" />
+		<EmbeddedResource Remove="Environment\**" />
 		<None Remove="Contexts\**" />
+		<None Remove="Environment\**" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -28,14 +32,6 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\OpenMud.Mudpiler.RuntimeEnvironment\OpenMud.Mudpiler.RuntimeEnvironment.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Folder Include="Environment\Operators\" />
-		<Folder Include="Environment\Proc\" />
-		<Folder Include="Environment\RuntimeTypes\" />
-		<Folder Include="Environment\Settings\" />
-		<Folder Include="Environment\WorldPiece\" />
 	</ItemGroup>
 
 </Project>

--- a/OpenMud.Mudpiler.Core/Systems/EntityVisualContextCacheSystem.cs
+++ b/OpenMud.Mudpiler.Core/Systems/EntityVisualContextCacheSystem.cs
@@ -66,8 +66,6 @@ public class EntityVisibilitySolver : IEntityVisibilitySolver
         if (fieldOfView < 0)
             fieldOfView = DEFAULT_VIEW_DISTANCE;
 
-        if(fieldOfView == 0)
-            return ImmutableDictionary<string, float>.Empty;
 
         if (HasValidVisible(entity, fieldOfView))
             return TruncateRange(entity.Get<EntityVisualContextCacheComponent>().VisibleEntities, fieldOfView);

--- a/OpenMud.Mudpiler.Tests/EcsTest/TestGame.cs
+++ b/OpenMud.Mudpiler.Tests/EcsTest/TestGame.cs
@@ -23,6 +23,11 @@ internal class TestGame
     private readonly LogicDirectory logicDirectory = new();
     private readonly List<GoRogueSenseAdapter> SenseAdapters = new();
 
+    public List<VerbRejectionMessage> VerbRejectionMessages { get; } = new();
+    public List<string> WorldMessages { get; } = new();
+    public Dictionary<string, List<string>> EntityMessages { get; } = new();
+
+
     public TestGame(IMudSceneBuilder builder, Assembly sourceAssembly)
     {
         var scheduler = new TimeTaskScheduler();
@@ -61,11 +66,13 @@ internal class TestGame
         _world.Subscribe<WorldEchoMessage>(On);
         _world.Subscribe<EntityEchoMessage>(On);
         _world.Subscribe<ConfigureSoundMessage>(On);
+        _world.Subscribe<VerbRejectionMessage>(On);
     }
 
-    public List<string> WorldMessages { get; } = new();
-    public Dictionary<string, List<string>> EntityMessages { get; } = new();
-
+    private void On(in VerbRejectionMessage message)
+    {
+        VerbRejectionMessages.Add(message);
+    }
 
     public List<ConfigureSoundMessage> WorldSoundConfig { get; } = new();
     public Dictionary<string, List<ConfigureSoundMessage>> EntitySoundConfig { get; } = new();
@@ -141,6 +148,17 @@ internal class TestGame
         return logicDirectory[
             _world.GetEntities().With<IdentifierComponent>(isSearch).AsEnumerable().Single()
                 .Get<LogicIdentifierComponent>().LogicInstanceId];
+    }
+
+    internal string GetInstanceNameByObjectDisplayName(string name)
+    {
+        bool isSearch(in DisplayNameComponent p)
+        {
+            return p.Name == name;
+        }
+
+        return _world.GetEntities().With<DisplayNameComponent>(isSearch).AsEnumerable().Single()
+                .Get<IdentifierComponent>().Name;
     }
 
     internal void Slide(string subject, int deltaX, int deltaY)

--- a/OpenMud.Mudpiler.Tests/EcsTest/VerbInteractionTest.cs
+++ b/OpenMud.Mudpiler.Tests/EcsTest/VerbInteractionTest.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using OpenMud.Mudpiler.Compiler.Core;
+using OpenMud.Mudpiler.Compiler.Project.Scene;
+using OpenMud.Mudpiler.Core.Components;
+using OpenMud.Mudpiler.Core.Scene;
+
+namespace OpenMud.Mudpiler.Tests.EcsTest
+{
+    internal class VerbInteractionTest
+    {
+
+        private static void Stabalize(TestGame w)
+        {
+            for (var i = 0; i < 100; i++)
+                w.Update(1);
+        }
+
+
+        [Test]
+        public void Oview_0_VerbInteraction()
+        {
+            var dmlCode =
+                @"
+
+/area/entry
+
+/turf/floor
+
+/mob/player
+    density = 1.0
+
+    New()
+        Move(locate(/area/entry))
+        world << ""spawn""
+
+    verb
+        goto_dest()
+            walk_to(src, locate(/obj/scroll))
+
+/turf/wall
+    density = 1.0
+
+    Enter(t)
+        world << ""Collision!""
+        return 0
+
+obj
+    verb
+        get()
+            set src in oview(0)
+            world << ""You get scroll.""
+            Move(usr)
+
+obj
+    scroll
+        name = ""scroll""
+";
+
+            var dmmCode =
+                @"
+""x"" = (/turf/wall)
+""."" = (/turf/floor)
+""e"" = (/turf/floor,/area/entry)
+""s"" = (/turf/floor,/obj/scroll)
+(1,1,1) = {""
+xxxxx
+x..sx
+xe..x
+xxxxx
+""}
+";
+            var entityBuilder = new BaseEntityBuilder();
+            var sceneBuilder = new DmmSceneBuilderFactory(entityBuilder).Build(dmmCode);
+
+            var withPlayerScene = new SimpleSceneBuilder(sceneBuilder.Bounds, w =>
+            {
+                sceneBuilder.Build(w);
+                var player = w.CreateEntity();
+                entityBuilder.CreateAtomic(player, "/mob/player", "player");
+                player.Set<PlayerCanImpersonateComponent>();
+            });
+
+            var assembly = Assembly.LoadFile(MsBuildDmlCompiler.Compile(dmlCode));
+
+            var g = new TestGame(withPlayerScene, assembly);
+            Stabalize(g);
+
+            var instance_name = g.GetInstanceNameByObjectDisplayName("scroll");
+
+            //This one will fail, player not near scroll.
+            g.ExecuteVerb("player", instance_name, "get", new string[0]);
+            Stabalize(g);
+
+            Assert.IsTrue(g.WorldMessages.SequenceEqual(new[] {
+            "spawn",
+            }));
+            
+            Assert.IsTrue(g.VerbRejectionMessages.Single().Source == "player");
+
+            g.ExecuteVerb("player", "player", "goto_dest", new string[0]);
+            Stabalize(g);
+
+            //This one will succeed, player is on top of scroll.
+            g.ExecuteVerb("player", instance_name, "get", new string[0]);
+
+            Stabalize(g);
+            Assert.IsTrue(g.WorldMessages.SequenceEqual(new[]
+            {
+            "spawn",
+            "You get scroll."
+            }));
+
+            Assert.IsTrue(g.VerbRejectionMessages.Count == 1);
+        }
+
+    }
+}

--- a/OpenMud.Mudpiler.Tests/EnvironmentTests/StringExpressionsTest.cs
+++ b/OpenMud.Mudpiler.Tests/EnvironmentTests/StringExpressionsTest.cs
@@ -74,4 +74,20 @@ public class StringExpressionsTest
         Assert.IsTrue(t["desc"] == "%this% is a string");
     }
 
+    [Test]
+    public void TestStringLiteralWithSlash()
+    {
+        var testCode =
+        @"
+/mob/bob
+    desc = ""icons\\rat.dmi""
+
+";
+        var dmlCode = Preprocessor.Preprocess("testFile.dml", ".", testCode, null, null);
+        var assembly = MsBuildDmlCompiler.Compile(dmlCode);
+        var system = MudEnvironment.Create(Assembly.LoadFile(assembly), new BaseDmlFramework());
+        var t = system.CreateAtomic("/mob/bob");
+        Assert.IsTrue(t["desc"] == "icons\\rat.dmi");
+    }
+
 }


### PR DESCRIPTION
- Resolved various issues when using the starter template project (OpenMud scaffold project)
- String escape characters not being processed correctly by the compiler
- OView(0) always returned zero found items, but items on the same tile as the subject and source should have been matched.

Added test cases to capture above regressions in the future.